### PR TITLE
Vagrantfileを修正。それぞれのdockerコンテナに別名を命名

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,13 +13,13 @@ Vagrant.configure(2) do |config|
     ansible.playbook = "playbook.yml"
   end
 
-  config.vm.provision "docker" do |d|
+  config.vm.provision "mysql-container", type: "docker" do |d|
     d.pull_images "mysql:5.6"
     d.run "mysql",
       image: "mysql:5.6",
       args: "-P -e MYSQL_ROOT_PASSWORD=otrspass"
   end
-  config.vm.provision "docker" do |d|
+  config.vm.provision "otrs-container", type: "docker" do |d|
     d.build_image "-t takipone/otrs /vagrant"
     d.run "takipone/otrs", args: "-p 80:80 -e OTRS_ENV=develop --link mysql:mysql -v /var/log/httpd:/var/log/httpd"
   end

--- a/otrs/Config.pm
+++ b/otrs/Config.pm
@@ -76,26 +76,6 @@ sub Load {
     # $Self->{SessionUseCookie} = 0;
     # $Self->{CheckMXRecord} = 0;
  
-    $Self->{'CheckEmailAddresses'} = 0;
-    $Self->{'CheckMXRecord'}       = 0;
-    $Self->{'Organization'}        = '';
-    $Self->{'LogModule'}           = 'Kernel::System::Log::File';
-    $Self->{'LogModule::LogFile'}  = '/tmp/otrs.log';
-    $Self->{'DefaultLanguage'}     = 'de';
-    $Self->{'DefaultCharset'}      = 'utf-8';
-    $Self->{'AdminEmail'}          = 'root@localhost';
-    $Self->{'Package::Timeout'}    = '120';
-    # Misc
-    $Self->{'Loader::Enabled::CSS'}  = 0;
-    $Self->{'Loader::Enabled::JS'}   = 0;
-    $Self->{'FAQ::Item::Field1'} =  {
-      'Caption' => 'Symptom',
-      'Prio' => '100',
-      'Show' => 'false'
-    };
-    # Add for ELB frontend
-    $Self->{SessionCheckRemoteIP} = 0;
-
     # ---------------------------------------------------- #
 
     # ---------------------------------------------------- #


### PR DESCRIPTION
理由：
    コンテナごとにライフサイクルの異なるプロビジョンを実現するため。
